### PR TITLE
let user specify the baseband serial number

### DIFF
--- a/tsschecker/tsschecker.h
+++ b/tsschecker/tsschecker.h
@@ -48,6 +48,7 @@ typedef struct{
     uint64_t bbgcid;
     size_t parsedApnonceLen;
     size_t parsedSepnonceLen;
+    uint8_t *bbsnum;
     size_t bbsnumSize;
     char generator[19];
     union{


### PR DESCRIPTION
With this, tsschecker can save valid BBTickets/baseband blobs for the device.

The value for `--bbsnum` can be acquired from ideviceinfo in base64 format (but tsschecker takes it in hex).
```
Mari tsschecker: bbticket-serial λ ideviceinfo -d -s
...
BasebandSerialNumber: xxxxxxxxx
BasebandVersion: 1.03.06
...
```
